### PR TITLE
Fix: Added typings to ms

### DIFF
--- a/ts-scripts/utils.ts
+++ b/ts-scripts/utils.ts
@@ -148,7 +148,7 @@ import {
   CHAINS,
 } from "@certusone/wormhole-sdk";
 
-export const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+export const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 // Temporarily here - will move to the typescript SDK soon so it can be directly imported from there!
 export async function getDeliveryHash(


### PR DESCRIPTION
The variable `ms` had `any` type that resulted in error while deploying:

`ts-scripts/utils.ts:151:23 - error TS7006: Parameter 'ms' implicitly has an 'any' type.
`